### PR TITLE
_prettify does not work with upper case input

### DIFF
--- a/lib/HTML/Table/FromDatabase.pm
+++ b/lib/HTML/Table/FromDatabase.pm
@@ -300,6 +300,7 @@ sub _perform_callback {
     return $callback->{transform}->($value, $row);
 }
 
+# lowercase input first to work on input that is already all uppercase
 sub _prettify {
     $_=lc($_); s{_}{ }g; s{\b(\w)}{\u$1}g; $_;
 }

--- a/lib/HTML/Table/FromDatabase.pm
+++ b/lib/HTML/Table/FromDatabase.pm
@@ -301,7 +301,7 @@ sub _perform_callback {
 }
 
 sub _prettify {
-    s{_}{ }g; s{\b(\w)}{\u$1}g; $_;
+    $_=lc($_); s{_}{ }g; s{\b(\w)}{\u$1}g; $_;
 }
 
 1;


### PR DESCRIPTION
Cool module, just learned of it.

As I am working with Oracle, the returned column headings are by default in upper case.

First changing the input in _prettify to lowercase allows the sub to work with uppercase input.

Jared Still
